### PR TITLE
Add persistent history logging for workout sessions

### DIFF
--- a/docs/history.txt
+++ b/docs/history.txt
@@ -1,0 +1,5 @@
+--------------------------------------------
+[22-03-2026, 22:13] PUSH workout
+benchpress:       :   67kg |  3 sets | 10 reps
+tricep pushdown:  :   27kg |  3 sets | 10 reps
+shoulder press:   :   20kg |  3 sets |  8 reps

--- a/docs/workouts.txt
+++ b/docs/workouts.txt
@@ -4,7 +4,7 @@ WORKOUT | legs | false
 EXERCISE | legpress | 0 | 0 | 0
 ---
 WORKOUT | push | false
-EXERCISE | benchpress | 65 | 3 | 10
-EXERCISE | tricep pushdown | 25 | 3 | 10
-EXERCISE | shoulder press | 0 | 0 | 0
+EXERCISE | benchpress | 67 | 3 | 10
+EXERCISE | tricep pushdown | 27 | 3 | 10
+EXERCISE | shoulder press | 20 | 3 | 8
 ---

--- a/src/main/java/seedu/gitswole/command/LogCommand.java
+++ b/src/main/java/seedu/gitswole/command/LogCommand.java
@@ -5,8 +5,10 @@ import seedu.gitswole.assets.Workout;
 import seedu.gitswole.assets.WorkoutList;
 import seedu.gitswole.exceptions.GitSwoleException;
 import seedu.gitswole.parser.Parser;
+import seedu.gitswole.storage.HistoryStorage;
 import seedu.gitswole.ui.Ui;
 
+import java.io.IOException;
 import java.util.logging.Level;
 
 /**
@@ -16,12 +18,13 @@ import java.util.logging.Level;
  * <ul>
  *   <li>{@code log w/WORKOUT_NAME} — starts a session and lists exercises</li>
  *   <li>{@code log e/EXERCISE_NAME [w/WORKOUT_NAME] [wt/WEIGHT] [s/SETS] [r/REPS]} 
- *   — updates stats for an exercise. If {@code w/} is omitted, the most recent 
- *   active session name is used.</li>
+ *   — updates stats for an exercise and appends to history log. 
+ *   If {@code w/} is omitted, the most recent active session name is used.</li>
  * </ul>
  */
 public class LogCommand extends Command {
     private String response;
+    private HistoryStorage historyStorage = new HistoryStorage();
 
     /**
      * Constructs a LogCommand with the raw user input string.
@@ -53,7 +56,7 @@ public class LogCommand extends Command {
     }
 
     /**
-     * Starts a logging session for a specific workout and displays the exercise list.
+     * Starts a logging session for a specific workout and records the header in history.
      *
      * @param workouts The list of available workouts.
      * @param ui       The UI to display the session start message.
@@ -72,6 +75,14 @@ public class LogCommand extends Command {
             throw new GitSwoleException(GitSwoleException.ErrorType.NOT_FOUND, workoutName);
         }
 
+        // Record the session start in the history file
+        try {
+            historyStorage.writeSeparator();
+            historyStorage.writeSessionHeader(workout.getWorkoutName());
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to write session header to history: " + e.getMessage());
+        }
+
         // Set the "sticky" active session name
         workouts.setActiveWorkoutName(workout.getWorkoutName());
 
@@ -85,7 +96,7 @@ public class LogCommand extends Command {
     }
 
     /**
-     * Updates the performance statistics for a specific exercise within a workout.
+     * Updates the performance statistics for a specific exercise and records it in history.
      * Uses the active workout session if the {@code w/} flag is omitted.
      *
      * @param workouts The list of available workouts.
@@ -128,6 +139,13 @@ public class LogCommand extends Command {
         exercise.setWeight(weight);
         exercise.setSets(sets);
         exercise.setReps(reps);
+
+        // Record the exercise log in the history file
+        try {
+            historyStorage.writeExerciseLog(exercise);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to write exercise log to history: " + e.getMessage());
+        }
 
         ui.showMessage("Stats updated for " + exerciseName + " in " + workoutName + "!");
         ui.printExercises(workout.getExerciseList());

--- a/src/main/java/seedu/gitswole/storage/HistoryStorage.java
+++ b/src/main/java/seedu/gitswole/storage/HistoryStorage.java
@@ -1,0 +1,67 @@
+package seedu.gitswole.storage;
+
+import seedu.gitswole.assets.Exercise;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Manages the persistent storage of workout session history.
+ * <p>
+ * This class handles writing formatted session logs to a history file,
+ * including timestamps, workout names, and exercise performance data.
+ */
+public class HistoryStorage {
+    private static final String HISTORY_FILE_PATH = "docs/history.txt";
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = 
+        DateTimeFormatter.ofPattern("dd-MM-yyyy, HH:mm");
+
+    /**
+     * Appends a session header to the history file.
+     * <p>
+     * Starts a new entry with the current date, time, and workout name.
+     *
+     * @param workoutName The name of the workout session being logged.
+     * @throws IOException If an I/O error occurs while writing to the file.
+     */
+    public void writeSessionHeader(String workoutName) throws IOException {
+        String timestamp = LocalDateTime.now().format(DATE_TIME_FORMATTER);
+        try (PrintWriter out = new PrintWriter(new FileWriter(HISTORY_FILE_PATH, true))) {
+            out.println("[" + timestamp + "] " + workoutName.toUpperCase() + " workout");
+        }
+    }
+
+    /**
+     * Appends an exercise log entry to the current session in the history file.
+     * <p>
+     * Formats the exercise details including name, weight, sets, and repetitions.
+     *
+     * @param exercise The {@link Exercise} object containing the performance data.
+     * @throws IOException If an I/O error occurs while writing to the file.
+     */
+    public void writeExerciseLog(Exercise exercise) throws IOException {
+        String logEntry = String.format("%-18s: %4dkg | %2d sets | %2d reps",
+                exercise.getExerciseName() + ":",
+                exercise.getWeight(),
+                exercise.getSets(),
+                exercise.getReps());
+        
+        try (PrintWriter out = new PrintWriter(new FileWriter(HISTORY_FILE_PATH, true))) {
+            out.println(logEntry);
+        }
+    }
+
+    /**
+     * Appends a visual separator to the history file to mark the end of a session.
+     *
+     * @throws IOException If an I/O error occurs while writing to the file.
+     */
+    public void writeSeparator() throws IOException {
+        try (PrintWriter out = new PrintWriter(new FileWriter(HISTORY_FILE_PATH, true))) {
+            out.println("--------------------------------------------");
+        }
+    }
+}


### PR DESCRIPTION
This PR implements a new history logging feature that records workout performance with timestamps in docs/history.txt. The format is optimized for readability and tracks individual exercises within a persistent session