### PR TITLE
Add session-specific remarks and smart overwriting to history log

### DIFF
--- a/docs/history.txt
+++ b/docs/history.txt
@@ -1,5 +1,7 @@
+
 --------------------------------------------
-[22-03-2026, 22:13] PUSH workout
-benchpress:       :   67kg |  3 sets | 10 reps
-tricep pushdown:  :   27kg |  3 sets | 10 reps
-shoulder press:   :   20kg |  3 sets |  8 reps
+[22-03-2026, 22:52] PUSH workout
+benchpress:       :   68kg |  3 sets | 10 reps
+  Remark: PR BABYYY
+shoulder press:   :   21kg |  3 sets | 10 reps
+  Remark: didn't hurt my shoulders

--- a/docs/workouts.txt
+++ b/docs/workouts.txt
@@ -4,7 +4,7 @@ WORKOUT | legs | false
 EXERCISE | legpress | 0 | 0 | 0
 ---
 WORKOUT | push | false
-EXERCISE | benchpress | 67 | 3 | 10
+EXERCISE | benchpress | 68 | 3 | 10
 EXERCISE | tricep pushdown | 27 | 3 | 10
-EXERCISE | shoulder press | 20 | 3 | 8
+EXERCISE | shoulder press | 21 | 3 | 10
 ---

--- a/src/main/java/seedu/gitswole/command/LogCommand.java
+++ b/src/main/java/seedu/gitswole/command/LogCommand.java
@@ -12,13 +12,13 @@ import java.io.IOException;
 import java.util.logging.Level;
 
 /**
- * Represents a command that logs performance data for a workout session.
+ * Represents a command that logs performance data for a workout session with smart overwriting.
  * <p>
  * Supported formats:
  * <ul>
  *   <li>{@code log w/WORKOUT_NAME} — starts a session and lists exercises</li>
- *   <li>{@code log e/EXERCISE_NAME [w/WORKOUT_NAME] [wt/WEIGHT] [s/SETS] [r/REPS]} 
- *   — updates stats for an exercise and appends to history log. 
+ *   <li>{@code log e/EXERCISE_NAME [w/WORKOUT_NAME] [wt/WEIGHT] [s/SETS] [r/REPS] [remark/REMARK]} 
+ *   — updates stats for an exercise and updates the history log in a smart way. 
  *   If {@code w/} is omitted, the most recent active session name is used.</li>
  * </ul>
  */
@@ -56,7 +56,9 @@ public class LogCommand extends Command {
     }
 
     /**
-     * Starts a logging session for a specific workout and records the header in history.
+     * Starts or resumes a logging session for a specific workout.
+     * <p>
+     * Only writes a new header if no session for this workout exists for today.
      *
      * @param workouts The list of available workouts.
      * @param ui       The UI to display the session start message.
@@ -75,29 +77,31 @@ public class LogCommand extends Command {
             throw new GitSwoleException(GitSwoleException.ErrorType.NOT_FOUND, workoutName);
         }
 
-        // Record the session start in the history file
+        // SMART CHECK: Only write header if a session doesn't exist for today
         try {
-            historyStorage.writeSeparator();
-            historyStorage.writeSessionHeader(workout.getWorkoutName());
+            if (!historyStorage.hasSessionToday(workout.getWorkoutName())) {
+                historyStorage.writeSessionHeader(workout.getWorkoutName());
+                ui.showMessage("Session started for " + workout.getWorkoutName() + "! Let's get those gains.");
+            } else {
+                ui.showMessage("Resuming your " + workout.getWorkoutName() + " session for today!");
+            }
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to write session header to history: " + e.getMessage());
+            LOGGER.log(Level.WARNING, "Failed to manage session header: " + e.getMessage());
         }
 
         // Set the "sticky" active session name
         workouts.setActiveWorkoutName(workout.getWorkoutName());
 
-        ui.showMessage("Session started for " + workout.getWorkoutName() + "! Let's get those gains.");
         ui.showLine();
         ui.showMessage(workout.getWorkoutName().toUpperCase() + " Workout Exercises:");
         ui.printExercises(workout.getExerciseList());
         ui.showLine();
-        ui.showMessage("Continue to log your workout by: log e/EXERCISE wt/WEIGHT s/SETS r/REPS");
+        ui.showMessage("Continue to log your workout by: log e/EXERCISE wt/WEIGHT s/SETS r/REPS remark/REMARK");
         ui.showLine();
     }
 
     /**
-     * Updates the performance statistics for a specific exercise and records it in history.
-     * Uses the active workout session if the {@code w/} flag is omitted.
+     * Updates statistics for an exercise and performs a smart update in the history file.
      *
      * @param workouts The list of available workouts.
      * @param ui       The UI to display the updated stats.
@@ -106,6 +110,7 @@ public class LogCommand extends Command {
     private void handleLogExercise(WorkoutList workouts, Ui ui) throws GitSwoleException {
         String exerciseName = Parser.parseValue(response, "e/");
         String workoutName = Parser.parseValue(response, "w/");
+        String remark = Parser.parseValue(response, "remark/");
 
         // Use the sticky session if w/ flag is missing
         if (workoutName == null) {
@@ -114,7 +119,7 @@ public class LogCommand extends Command {
 
         if (exerciseName == null || workoutName == null) {
             LOGGER.log(Level.WARNING, "LogExercise failed: Missing e/ flag or workout context.");
-            String usage = "log e/EXERCISE [w/WORKOUT] wt/WEIGHT s/SETS r/REPS";
+            String usage = "log e/EXERCISE [w/WORKOUT] wt/WEIGHT s/SETS r/REPS [remark/REMARK]";
             throw new GitSwoleException(GitSwoleException.ErrorType.INCOMPLETE_COMMAND, usage);
         }
 
@@ -131,7 +136,7 @@ public class LogCommand extends Command {
             throw new GitSwoleException(GitSwoleException.ErrorType.NOT_FOUND, exerciseName);
         }
 
-        // Update the stats: use existing value as default if flag is missing
+        // Update the stats in memory
         int weight = Parser.parseOptionalInt(response, "wt/", exercise.getWeight());
         int sets = Parser.parseOptionalInt(response, "s/", exercise.getSets());
         int reps = Parser.parseOptionalInt(response, "r/", exercise.getReps());
@@ -140,14 +145,21 @@ public class LogCommand extends Command {
         exercise.setSets(sets);
         exercise.setReps(reps);
 
-        // Record the exercise log in the history file
+        // SMART UPDATE: Update the specific exercise within today's session block in the file
         try {
-            historyStorage.writeExerciseLog(exercise);
+            // Ensure session exists (in case user jumped straight to log e/ without log w/)
+            if (!historyStorage.hasSessionToday(workoutName)) {
+                historyStorage.writeSessionHeader(workoutName);
+            }
+            historyStorage.updateExerciseLog(workoutName, exercise, remark);
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to write exercise log to history: " + e.getMessage());
+            LOGGER.log(Level.WARNING, "Failed to update exercise log in history: " + e.getMessage());
         }
 
         ui.showMessage("Stats updated for " + exerciseName + " in " + workoutName + "!");
+        if (remark != null && !remark.isBlank()) {
+            ui.showMessage("Remark added: " + remark.trim());
+        }
         ui.printExercises(workout.getExerciseList());
         ui.showLine();
     }

--- a/src/main/java/seedu/gitswole/storage/HistoryStorage.java
+++ b/src/main/java/seedu/gitswole/storage/HistoryStorage.java
@@ -2,66 +2,164 @@ package seedu.gitswole.storage;
 
 import seedu.gitswole.assets.Exercise;
 
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Manages the persistent storage of workout session history.
+ * Manages the persistent storage of workout session history with smart overwriting.
  * <p>
- * This class handles writing formatted session logs to a history file,
- * including timestamps, workout names, and exercise performance data.
+ * This class identifies session blocks by date and workout name to prevent duplicates
+ * and allows for updating existing exercise logs within a session.
  */
 public class HistoryStorage {
     private static final String HISTORY_FILE_PATH = "docs/history.txt";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = 
-        DateTimeFormatter.ofPattern("dd-MM-yyyy, HH:mm");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+    private static final DateTimeFormatter FULL_FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy, HH:mm");
 
     /**
-     * Appends a session header to the history file.
-     * <p>
-     * Starts a new entry with the current date, time, and workout name.
+     * Checks if a session for the given workout already exists for today.
      *
-     * @param workoutName The name of the workout session being logged.
-     * @throws IOException If an I/O error occurs while writing to the file.
+     * @param workoutName The name of the workout to check.
+     * @return {@code true} if a session header for today exists; {@code false} otherwise.
+     * @throws IOException If an I/O error occurs.
+     */
+    public boolean hasSessionToday(String workoutName) throws IOException {
+        ensureFileExists();
+        List<String> lines = Files.readAllLines(Paths.get(HISTORY_FILE_PATH));
+        String today = LocalDateTime.now().format(DATE_FORMATTER);
+        String headerTrigger = "[" + today;
+        String workoutTrigger = workoutName.toUpperCase() + " workout";
+
+        for (String line : lines) {
+            if (line.startsWith(headerTrigger) && line.contains(workoutTrigger)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Appends a new session header to the history file.
+     *
+     * @param workoutName The name of the workout session.
+     * @throws IOException If an I/O error occurs.
      */
     public void writeSessionHeader(String workoutName) throws IOException {
-        String timestamp = LocalDateTime.now().format(DATE_TIME_FORMATTER);
-        try (PrintWriter out = new PrintWriter(new FileWriter(HISTORY_FILE_PATH, true))) {
-            out.println("[" + timestamp + "] " + workoutName.toUpperCase() + " workout");
-        }
-    }
-
-    /**
-     * Appends an exercise log entry to the current session in the history file.
-     * <p>
-     * Formats the exercise details including name, weight, sets, and repetitions.
-     *
-     * @param exercise The {@link Exercise} object containing the performance data.
-     * @throws IOException If an I/O error occurs while writing to the file.
-     */
-    public void writeExerciseLog(Exercise exercise) throws IOException {
-        String logEntry = String.format("%-18s: %4dkg | %2d sets | %2d reps",
-                exercise.getExerciseName() + ":",
-                exercise.getWeight(),
-                exercise.getSets(),
-                exercise.getReps());
+        ensureFileExists();
+        String timestamp = LocalDateTime.now().format(FULL_FORMATTER);
+        Path path = Paths.get(HISTORY_FILE_PATH);
+        List<String> lines = new ArrayList<>(Files.readAllLines(path));
         
-        try (PrintWriter out = new PrintWriter(new FileWriter(HISTORY_FILE_PATH, true))) {
-            out.println(logEntry);
+        if (!lines.isEmpty()) {
+            lines.add("--------------------------------------------");
         }
+        
+        lines.add("[" + timestamp + "] " + workoutName.toUpperCase() + " workout");
+        Files.write(path, lines);
     }
 
     /**
-     * Appends a visual separator to the history file to mark the end of a session.
+     * Updates or adds an exercise log in the history file for today's session.
+     * <p>
+     * This method coordinates the identification of the session block and applies the update.
      *
-     * @throws IOException If an I/O error occurs while writing to the file.
+     * @param workoutName  The name of the workout session.
+     * @param exercise     The {@link Exercise} object to log.
+     * @param remark       An optional comment for the session.
+     * @throws IOException If an I/O error occurs.
      */
-    public void writeSeparator() throws IOException {
-        try (PrintWriter out = new PrintWriter(new FileWriter(HISTORY_FILE_PATH, true))) {
-            out.println("--------------------------------------------");
+    public void updateExerciseLog(String workoutName, Exercise exercise, String remark) throws IOException {
+        ensureFileExists();
+        Path path = Paths.get(HISTORY_FILE_PATH);
+        List<String> lines = new ArrayList<>(Files.readAllLines(path));
+        
+        int startIndex = findSessionStartIndex(lines, workoutName);
+        if (startIndex == -1) {
+            return;
         }
+
+        int endIndex = findSessionEndIndex(lines, startIndex);
+        applyExerciseUpdate(lines, startIndex, endIndex, exercise, remark);
+        
+        Files.write(path, lines);
+    }
+
+    private int findSessionStartIndex(List<String> lines, String workoutName) {
+        String today = LocalDateTime.now().format(DATE_FORMATTER);
+        String trigger = "[" + today;
+        String workoutHeader = workoutName.toUpperCase() + " workout";
+
+        for (int i = lines.size() - 1; i >= 0; i--) {
+            if (lines.get(i).startsWith(trigger) && lines.get(i).contains(workoutHeader)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int findSessionEndIndex(List<String> lines, int startIndex) {
+        for (int i = startIndex + 1; i < lines.size(); i++) {
+            if (lines.get(i).startsWith("---")) {
+                return i;
+            }
+        }
+        return lines.size();
+    }
+
+    private void applyExerciseUpdate(List<String> lines, int start, int end, Exercise exercise, String remark) {
+        String exerciseKey = exercise.getExerciseName() + ":";
+        String formattedLine = formatExerciseLine(exercise);
+        
+        for (int i = start + 1; i < end; i++) {
+            if (lines.get(i).trim().startsWith(exerciseKey)) {
+                updateExistingEntry(lines, i, formattedLine, remark);
+                return;
+            }
+        }
+        
+        addNewEntry(lines, end, formattedLine, remark);
+    }
+
+    private void updateExistingEntry(List<String> lines, int index, String formattedLine, String remark) {
+        lines.set(index, formattedLine);
+        
+        // Remove old remark if it exists in the next line
+        if (index + 1 < lines.size() && lines.get(index + 1).trim().startsWith("Remark:")) {
+            lines.remove(index + 1);
+        }
+        
+        // Insert new remark if provided
+        if (remark != null && !remark.isBlank()) {
+            lines.add(index + 1, "  Remark: " + remark.trim());
+        }
+    }
+
+    private void addNewEntry(List<String> lines, int insertionPoint, String formattedLine, String remark) {
+        lines.add(insertionPoint, formattedLine);
+        if (remark != null && !remark.isBlank()) {
+            lines.add(insertionPoint + 1, "  Remark: " + remark.trim());
+        }
+    }
+
+    private String formatExerciseLine(Exercise exercise) {
+        String nameWithColon = exercise.getExerciseName() + ":";
+        return String.format("%-18s: %4dkg | %2d sets | %2d reps",
+                nameWithColon, exercise.getWeight(), 
+                exercise.getSets(), exercise.getReps());
+    }
+
+    private void ensureFileExists() throws IOException {
+        Path path = Paths.get(HISTORY_FILE_PATH);
+        if (Files.exists(path)) {
+            return;
+        }
+        Files.createDirectories(path.getParent());
+        Files.createFile(path);
     }
 }


### PR DESCRIPTION
Fixes #24 

- Introduces remark/ flag for logging session-specific comments.
- Implements "Smart Overwrite" logic to prevent duplicate headers and surgically update exercise logs within a single day's session.
- Refactored HistoryStorage to follow CS2113 standards (SLAP, low nesting, guard clauses).